### PR TITLE
IOS correct props

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,11 +102,12 @@ class DatePicker extends Component {
 
     handlePressed = async () => {
       const { startDate, onError } = this.props
+      const { date } = this.state
 
       if (isAndroid) {
         try {
           const { action, year, month, day } = await DatePickerAndroid.open({
-            date: startDate
+            date: date || startDate
           })
 
           if (action !== DatePickerAndroid.dismissedAction) {
@@ -180,7 +181,7 @@ class DatePicker extends Component {
                 </View>
                 <DatePickerIOS
                   mode='date'
-                  date={startDate || new Date()}
+                  date={date || startDate}
                   onDateChange={this.handleDateChange}
                   maximumDate={maxDate}
                   minimumDate={minDate}

--- a/index.js
+++ b/index.js
@@ -180,8 +180,10 @@ class DatePicker extends Component {
                 </View>
                 <DatePickerIOS
                   mode='date'
-                  date={date || new Date()}
+                  date={startDate || new Date()}
                   onDateChange={this.handleDateChange}
+                  maximumDate={maxDate}
+                  minimumDate={minDate}
                   {...props}
                 />
               </View>


### PR DESCRIPTION
IOS and Android have different props names.
The IOS ones were wrong, so the **startDate**, **maxDate** and **minDate** could not be setted.

With this change, this will work on both platforms.
Cheers 🍻 