### PR TITLE
Keep The Input Visible When Modal Opens

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ class DatePicker extends Component {
               </View>
             </View>
           </Modal>
-          {!showIOSModal && renderDate(this.getDateObj())}
+          {renderDate(this.getDateObj())}
         </TouchableOpacity>
       )
     }


### PR DESCRIPTION
When the modal opens, the `renderDate` component disappears, causing movement on the UI.
Maybe this is the desired behavior.
I just create the PR in case that someone else need the fix.

Thanks